### PR TITLE
Fix paralle's subcommand for zsh as default shell

### DIFF
--- a/afl-pcmin
+++ b/afl-pcmin
@@ -374,7 +374,7 @@ echo "[*] Finding best candidates for each tuple..."
 #
 #done < <(ls -rS "$IN_DIR")
 
-ls -rS "$IN_DIR" | parallel -k -I FN sed "s^\$^\ FN^" "$TRACE_DIR/FN" >> "$TRACE_DIR/.candidate_list"
+ls -rS "$IN_DIR" | parallel -k -I FN sed 's^\$^\ FN^' "$TRACE_DIR/FN" >> "$TRACE_DIR/.candidate_list"
 
 echo
 


### PR DESCRIPTION
parallel will run the subcommand using $SHELL. So the parallel command
line, double-quoted string, will be substituted twice, one by bash (the
script shell) and one by $SHELL.

However, zsh and bash have different string substitution behavior -- zsh
will substitute "$^" but bash won't.

Change to use single quote string.

```
$ echo foo | SHELL=/bin/bash parallel echo "\$^"
$^ foo
$ echo foo | SHELL=/bin/zsh parallel echo "\$^"
foo
$ echo foo | SHELL=/bin/zsh parallel echo '\$^'
$^ foo
```
